### PR TITLE
Add support for alternate state selection

### DIFF
--- a/README.org
+++ b/README.org
@@ -41,3 +41,13 @@ enabled. They can also be added using =evil-unimpaired-define-pair=.
   (evil-unimpaired-define-pair "e" '(move-text-up . move-text-down) '(normal visual))
   (evil-unimpaired-define-pair "q" '(flycheck-previous-error . flycheck-next-error))
 #+END_SRC
+
+*** Evil States
+The state(s) where the keybinds are active is set by
+=evil-unimpaired-state=. By default this is set to ='normal=.
+
+To let evil-unimpaired work in read only buffers set it to ='motion=
+#+BEGIN_SRC emacs-list
+  (setq evil-unimpaired-state 'motion) 
+#+END_SRC
+

--- a/evil-unimpaired.el
+++ b/evil-unimpaired.el
@@ -36,7 +36,10 @@
     ("t" (evil-unimpaired-previous-frame . evil-unimpaired-next-frame))
     ("w" (previous-multiframe-window . next-multiframe-window))
     ("p" (evil-unimpaired-paste-above . evil-unimpaired-paste-below)))
-  "binding pairs for evil normal state")
+  "binding pairs for evil-unimpaired-state")
+
+(defvar evil-unimpaired-state 'normal
+  "The state(s) which evil-unimpaired should be enabled for.")
 
 (defun evil-unimpaired--find-relative-filename (offset)
   (when buffer-file-name
@@ -97,18 +100,28 @@
   :global t
   (evil-normalize-keymaps))
 
-(defun evil-unimpaired-define-pair (key funcs &optional state)
+(defun evil-unimpaired-define-pair (key funcs)
   "create an evil-unimpaired pair binding.
 Bind KEY in STATE to PREV and NEXT. STATE can be an evil state or
 a list of states and defaults to 'normal."
   (dolist (fetcher '(car cdr))
-    (let ((evil-state (if state state 'normal))
-	  (key-binding (kbd (concat (funcall fetcher evil-unimpaired-leader-keys) " " key)))
+    (let ((key-binding (kbd (concat (funcall fetcher evil-unimpaired-leader-keys) " " key)))
 	  (func (funcall fetcher funcs)))
-      (evil-define-key evil-state evil-unimpaired-mode-map key-binding func))))
+      (evil-define-key
+	evil-unimpaired-state evil-unimpaired-mode-map key-binding func))))
 
-(dolist (pair evil-unimpaired-default-pairs)
-  (apply 'evil-unimpaired-define-pair pair))
+(defun evil-unimpaired-define-keymap ()
+  "Build the evil-unimpaired keymap. This is setup as a function because it
+needs to be run each time the mode is activated in case the values of the control
+variables have changed:
+* evil-unimpaired-leader-keys
+* evil-unimpaired-default-pairs
+* evil-unimpaired-state
+"
+  (dolist (pair evil-unimpaired-default-pairs)
+    (apply 'evil-unimpaired-define-pair pair)))
+
+(add-hook 'evil-unimpaired-mode-hook 'evil-unimpaired-define-keymap)
 
 (provide 'evil-unimpaired)
 ;;; evil-unimpaired.el ends here.


### PR DESCRIPTION
I ran into an issue where the buffer and window motion bindings would get stuck on read-only buffers, so I added support for enabled state configuration.

This was achieved by:
* Adding a new evil-unimpaired-state variable.
* Adding a mode hook which updates the keymap. This ensures the keymap is always reflective of configuration changes.